### PR TITLE
Ensure Debug Bar plugin is installed

### DIFF
--- a/modules/debugextras/manifests/init.pp
+++ b/modules/debugextras/manifests/init.pp
@@ -31,6 +31,11 @@ class debugextras (
     location => '/vagrant/wp',
     require  => [ Class['wp'], Wp::Plugin['developer'] ],
   }
+  wp::plugin { 'debug-bar':
+    ensure   => enabled,
+    location => '/vagrant/wp',
+    require  => Class['wp'],
+  }
   wp::plugin { 'debug-bar-console':
     ensure   => enabled,
     location => '/vagrant/wp',


### PR DESCRIPTION
Even though this extends the Debugging Chassis package, it loads first, which means
the plugins that rely on Debug Bar don't get automatically installed. This fixes that to
ensure we're loading Debug Bar, even though it's going to be loaded later by Debugging.